### PR TITLE
🧹 replace 'any' types in restore_snapshot parameter

### DIFF
--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { SERVER_CONFIG, RESOURCE_URIS } from "../types.js";
-import type { ConfidenceVector } from "../types.js";
+import type { ConfidenceVector, ThoughtNode, ThoughtEdge } from "../types.js";
 import { getGraphInstance, ThoughtGraph } from "../graph/index.js";
 import { getContextInstance } from "../context/index.js";
 
@@ -431,7 +431,7 @@ export function createServerInstance(): McpServer {
             },
             annotations: { destructiveHint: true }
         },
-        async ({ snapshot }: { snapshot: { nodes: any[]; edges: any[]; nodeCounter: number } }) => {
+        async ({ snapshot }: { snapshot: { nodes: ThoughtNode[]; edges: ThoughtEdge[]; nodeCounter: number } }) => {
             try {
                 const beforeCount = graph.size;
                 graph.restoreSnapshot(snapshot);


### PR DESCRIPTION
Replaced 'any' types in the `restore_snapshot` tool parameter with `ThoughtNode[]` and `ThoughtEdge[]` types. This improves maintainability and readability by using the specific interfaces defined in the codebase.

---
*PR created automatically by Jules for task [16165204897747486243](https://jules.google.com/task/16165204897747486243) started by @Abderraouf-yt*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for internal snapshot restoration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->